### PR TITLE
Fix bug when arrays differ only in the number of items they contain

### DIFF
--- a/PesterMatchArray.Tests.ps1
+++ b/PesterMatchArray.Tests.ps1
@@ -25,6 +25,9 @@ Describe "MatchArrayUnordered" {
     It "returns false if arrays differ in length" {
         , (@(1)) | Should Not MatchArrayUnordered @(1, 1)
     }
+    It "returns false if arrays differ in the number of each item" {
+        , (@(1, 1, 2)) | Should Not MatchArrayUnordered @(1, 2, 2)
+    }
 }
 
 
@@ -50,5 +53,8 @@ Describe "MatchArrayOrdered" {
     }
     It "returns false if arrays differ in length" {
         , @(1)  | Should Not MatchArrayOrdered  @(1, 1)
+    }
+    It "returns false if arrays differ in the number of each item" {
+        , (@(1, 1, 2)) | Should Not MatchArrayOrdered @(1, 2, 2)
     }
 }

--- a/PesterMatchArray.ps1
+++ b/PesterMatchArray.ps1
@@ -25,14 +25,22 @@ function PesterMatchArrayUnordered($ActualValue, $ExpectedValue, [switch] $Negat
 } 
 function FindMismatchedValueUnordered($ActualValue, $ExpectedValue) {
     $ActualValue = @($ActualValue)
-    for ($i = 0; $i -lt $ExpectedValue.Length; $i++) {
-        if (-not($ActualValue -contains $ExpectedValue[$i])) {
-            return "Expected: {$ExpectedValue}. Actual: {$ActualValue}. Actual is missing item: $($ExpectedValue[$i])"
+    $ExpectedGroups = $ExpectedValue | Group-Object | Sort-Object -Property Name
+    $ActualGroups = $ActualValue | Group-Object | Sort-Object -Property Name
+    for ($i = 0; $i -lt $ExpectedGroups.Length; $i++) {
+        if ( ($i -ge $ActualGroups.Length) `
+                -or (-not($ActualGroups[$i].Name -eq $ExpectedGroups[$i].Name))) {
+            return "Expected: {$ExpectedValue}. Actual: {$ActualValue}. Actual is missing item: $($ExpectedGroups[$i].Name)"
+        }
+        if (-not($ActualGroups[$i].Count -eq $ExpectedGroups[$i].Count)) {
+            return "Expected: {$ExpectedValue}. Actual: {$ActualValue}. Actual has $($ActualGroups[$i].Count) of item '$($ExpectedGroups[$i].Name)', expected $($ExpectedGroups[$i].Count)"
         }
     }
-    for ($i = 0; $i -lt $value.Length; $i++) {
-        if (-not($ExpectedValue -contains $ActualValue[$i])) {
-            return "Expected: {$ExpectedValue}. Actual: {$ActualValue}. Actual contains extra item: $($ActualValue[$i])"
+    for ($i = 0; $i -lt $ActualGroups.Length; $i++) {
+        # check for items in actual not in expected
+        if ( ($i -ge $ExpectedGroups.Length) `
+                -or (-not($ExpectedGroups[$i].Name -eq $ActualGroups[$i].Name))) {
+            return "Expected: {$ExpectedValue}. Actual: {$ActualValue}. Expected doesn't have item: $($ActualGroups[$i].Name)"
         }
     }
     if ($ActualValue.Length -ne $ExpectedValue.Length) {


### PR DESCRIPTION
When the arrays contained the same items in differing quantities they were erroneously deemed to be matching.

E.g. `@(1, 1, 3)` and `@(1, 3, 3)`

This PR fixes the bug